### PR TITLE
now temporary event gets destroyed when you exit the page

### DIFF
--- a/planit-react/src/pages/CreateEvent/CreateEvent.jsx
+++ b/planit-react/src/pages/CreateEvent/CreateEvent.jsx
@@ -42,7 +42,20 @@ const CreateEvent = () => {
       createTempEvent();
       hasMountedRef.current = true;
     }
-  }, []);
+
+    // Cleanup function
+    return async () => {
+      if (eventId) {
+        console.log("Destroying temporary event...");
+        const ParseEvents = Parse.Object.extend("Events");
+        const query = new Parse.Query(ParseEvents);
+        const tempEvent = await query.get(eventId);
+        if (tempEvent) {
+          await tempEvent.destroy();
+        }
+      }
+    };
+  }, [eventId]);
 
   /**
    * Handles the form submission for creating an event.


### PR DESCRIPTION
The temporary event gets destroyed when you exit the create event page